### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unsupervised Representation Learning with Deep Convolutional Generative Adversarial Networks
 
-###Tensorflow implementation
+### Tensorflow implementation
   * All the codes in this project are mere replication of [Theano version](https://github.com/Newmu/dcgan_code)
 
 ### Code


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
